### PR TITLE
pygeoapi_plugins refit

### DIFF
--- a/nldi_xstool/process/xsatendpts.py
+++ b/nldi_xstool/process/xsatendpts.py
@@ -1,0 +1,143 @@
+import logging
+import time
+
+from nldi_xstool.nldi_xstool import getXSAtEndPts
+from nldi_xstool.nldi_xstool import getXSAtPoint
+from pygeoapi.process.base import BaseProcessor
+
+LOGGER = logging.getLogger(__name__)
+
+PROCESS_METADATA = {
+    "version": "0.1.0",
+    "id": "nldi-xsatendpts",
+    "title": "NLDI xsatendpts process",
+    "description": "NLDI xsatendpts process",
+    "keywords": ["NLDI xsatendpts"],
+    "links": [
+        {
+            "type": "text/html",
+            "rel": "canonical",
+            "title": "information",
+            "href": "https://example.org/process",
+            "hreflang": "en-US",
+        }
+    ],
+    "inputs": [
+        {
+            "id": "lat",
+            "title": "lat",
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "list",
+                    "valueDefinition": {"anyValue": True},
+                }
+            },
+            "minOccurs": 2,
+            "maxOccurs": 2,
+        },
+        {
+            "id": "lon",
+            "title": "lon",
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "list",
+                    "valueDefinition": {"anyValue": True},
+                }
+            },
+            "minOccurs": 2,
+            "maxOccurs": 2,
+        },
+        {
+            "id": "numpts",
+            "title": "numpts",
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "int",
+                    "valueDefinition": {"anyValue": True},
+                }
+            },
+            "minOccurs": 1,
+            "maxOccurs": 1,
+        },
+        {
+            "id": "3dep_res",
+            "title": "resolution",
+            "abstract": "Resolution of 3dep elevation data",
+            "minOccurs": 1,
+            "maxOccurs": 1,
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "enum",
+                    "valueDefinition": {
+                        "anyValue": False,
+                        "defaultValue": "10",
+                        "possibleValues": ["30", "10", "5", "3", "1"],
+                    },
+                }
+            },
+        },
+    ],
+    "outputs": [
+        {
+            "id": "nldi-xsatendpts-response",
+            "title": "output nldi-xsatendpts",
+            "output": {"formats": [{"mimeType": "application/json"}]},
+        }
+    ],
+    "example": {
+        "inputs": [
+            {"id": "lat", "value": [40.267720, 40.270568], "type": "text/plain"},
+            {"id": "lon", "value": [-103.801086, -103.80097], "type": "text/plain"},
+            {"id": "numpts", "value": "101", "type": "text/plain"},
+            {"id": "3dep_res", "value": "1", "type": "text/plain"},
+        ]
+    },
+}
+
+
+class NLDIXSAtEndPtsProcessor(BaseProcessor):
+    """NLDI Split Catchment Processor"""
+
+    def __init__(self, provider_def):
+        """
+        Initialize object
+        :param provider_def: provider definition
+        :returns: pygeoapi.process.nldi_delineate.NLDIDelineateProcessor
+        """
+
+        BaseProcessor.__init__(self, provider_def, PROCESS_METADATA)
+
+    def execute(self, data):
+
+        print("before data assign")
+        print(data)
+        mimetype = "application/json"
+        lat = list(data["lat"])
+        lon = list(data["lon"])
+        numpts = int(data["numpts"])
+        res = float(data["3dep_res"])
+
+        print(lat, lon, numpts, res)
+
+        timeBefore = time.perf_counter()
+
+        print("before function")
+        results = getXSAtEndPts(
+            path=[(lon[0], lat[0]), (lon[1], lat[1])],
+            numpts=numpts,
+            res=res,
+            crs="epsg:4326",
+        )
+        print("after function")
+        # print(results)
+
+        timeAfter = time.perf_counter()
+        totalTime = timeAfter - timeBefore
+        print("Total Time:", totalTime)
+
+        outputs = [{"id": "nldi-xsatendpts-response", "value": results.to_json()}]
+        # print(results)
+        return mimetype, results.to_json()
+
+    def __repr__(self):
+        return "<NLDIXSAtEndPtsProcessor> {}".format(self.nldi - xsatendpts - response)

--- a/nldi_xstool/process/xsatpoint.py
+++ b/nldi_xstool/process/xsatpoint.py
@@ -1,0 +1,130 @@
+import logging
+import time
+
+from nldi_xstool.nldi_xstool import getXSAtPoint
+from pygeoapi.process.base import BaseProcessor
+
+LOGGER = logging.getLogger(__name__)
+
+PROCESS_METADATA = {
+    "version": "0.1.0",
+    "id": "nldi-xsatpoint",
+    "title": "NLDI xsatpoint process",
+    "description": "NLDI xsatpoint process",
+    "keywords": ["NLDI xsatpoint"],
+    "links": [
+        {
+            "type": "text/html",
+            "rel": "canonical",
+            "title": "information",
+            "href": "https://example.org/process",
+            "hreflang": "en-US",
+        }
+    ],
+    "inputs": [
+        {
+            "id": "lat",
+            "title": "lat",
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "float",
+                    "valueDefinition": {"anyValue": True},
+                }
+            },
+            "minOccurs": 1,
+            "maxOccurs": 1,
+        },
+        {
+            "id": "lon",
+            "title": "lon",
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "float",
+                    "valueDefinition": {"anyValue": True},
+                }
+            },
+            "minOccurs": 1,
+            "maxOccurs": 1,
+        },
+        {
+            "id": "width",
+            "title": "width",
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "float",
+                    "valueDefinition": {"anyValue": True},
+                }
+            },
+            "minOccurs": 1,
+            "maxOccurs": 1,
+        },
+        {
+            "id": "numpts",
+            "title": "numpts",
+            "input": {
+                "literalDataDomain": {
+                    "dataType": "int",
+                    "valueDefinition": {"anyValue": True},
+                }
+            },
+            "minOccurs": 1,
+            "maxOccurs": 1,
+        },
+    ],
+    "outputs": [
+        {
+            "id": "nldi-xsatpoint-response",
+            "title": "output nldi-xsatpoint",
+            "output": {"formats": [{"mimeType": "application/json"}]},
+        }
+    ],
+    "example": {
+        "inputs": [
+            {"id": "lat", "value": "40.2684", "type": "text/plain"},
+            {"id": "lon", "value": "-103.80119", "type": "text/plain"},
+            {"id": "width", "value": "1000.0", "type": "text/plain"},
+            {"id": "numpts", "value": "101", "type": "text/plain"},
+        ]
+    },
+}
+
+
+class NLDIXSAtPointProcessor(BaseProcessor):
+    """NLDI Split Catchment Processor"""
+
+    def __init__(self, provider_def):
+        """
+        Initialize object
+        :param provider_def: provider definition
+        :returns: pygeoapi.process.nldi_delineate.NLDIDelineateProcessor
+        """
+
+        BaseProcessor.__init__(self, provider_def, PROCESS_METADATA)
+
+    def execute(self, data):
+
+        mimetype = "application/json"
+        lat = float(data["lat"])
+        lon = float(data["lon"])
+        numpts = int(data["numpts"])
+        width = float(data["width"])
+
+        # print(lat, lon, width, numpts)
+
+        timeBefore = time.perf_counter()
+
+        # print("before function")
+        results = getXSAtPoint((lon, lat), numpts, width)
+        # print("after function")
+        # print(results)
+
+        timeAfter = time.perf_counter()
+        totalTime = timeAfter - timeBefore
+        print("Total Time:", totalTime)
+
+        outputs = [{"id": "nldi-xsatpoint-response", "value": results.to_json()}]
+        # print(results)
+        return mimetype, results.to_json()
+
+    def __repr__(self):
+        return "<NLDIXSAtPointProcessor> {}".format(self.nldi - xsatpoint - response)

--- a/requirements_dev.yml
+++ b/requirements_dev.yml
@@ -33,3 +33,4 @@ dependencies:
  - descartes
  - numba
  - owslib
+ - pygeoapi


### PR DESCRIPTION
This PR makes nldi_xstool able to work with the new pygeoapi restructure, and makes it installable directly into the new tool. The processors are now contained within the library for nldi_xstool directly, which makes it far simpler to roll out the plugin without needing coding modifications to the USGS pygeoapi tool.